### PR TITLE
perf: Make CEmu timing instrumentation opt-in

### DIFF
--- a/android/app/src/main/cpp/cemu/CMakeLists.txt
+++ b/android/app/src/main/cpp/cemu/CMakeLists.txt
@@ -1,6 +1,10 @@
 # CEmu Backend Build Configuration
 # This file is included when USE_CEMU_BACKEND is ON
 
+# Option to enable performance instrumentation (adds significant overhead)
+# Use only for debugging performance issues
+option(CEMU_PERF_INSTRUMENTATION "Enable timing instrumentation in CEmu adapter (adds overhead)" OFF)
+
 # CRITICAL: Force release optimizations even in debug builds
 # Android CMake debug builds use -O0 by default which makes CEmu unusably slow
 # These MUST be set BEFORE any add_library() calls
@@ -57,6 +61,12 @@ target_include_directories(cemu_adapter PUBLIC
 target_compile_options(cemu_adapter PRIVATE
     -O3 -ffast-math -DNDEBUG
 )
+
+# Enable performance instrumentation if requested (adds ~6 syscalls per loop iteration)
+if(CEMU_PERF_INSTRUMENTATION)
+    message(STATUS "CEmu performance instrumentation ENABLED (debug only)")
+    target_compile_definitions(cemu_adapter PRIVATE CEMU_PERF_INSTRUMENTATION)
+endif()
 
 target_link_libraries(cemu_adapter
     cemucore


### PR DESCRIPTION
## Summary

- Wraps all `clock_gettime()` calls and timing stats in `#ifdef CEMU_PERF_INSTRUMENTATION`
- Eliminates 6+ syscalls per loop iteration in the hot emulation path
- Adds `--perf` flag to build script for enabling instrumentation when debugging

## Problem

The CEmu adapter had timing instrumentation that was always enabled, adding significant overhead:
- 6 `clock_gettime(CLOCK_MONOTONIC)` syscalls per loop iteration
- Each syscall costs ~50-200ns on ARM Android devices
- This caused CEmu to perform much worse than the Rust implementation on Android

## Solution

Made the instrumentation compile-time optional via `CEMU_PERF_INSTRUMENTATION` define.

## Usage

```bash
# Normal build (fast, no instrumentation)
./scripts/build-android-cemu-release.sh

# With performance instrumentation (for debugging)
./scripts/build-android-cemu-release.sh --perf
```

## Test plan

- [ ] Build CEmu backend without `--perf` flag and verify no `[Perf]` logs appear
- [ ] Build with `--perf` flag and verify timing stats are logged
- [ ] Compare frame timing between instrumented and non-instrumented builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)