### PR TITLE
feat: Change default speed to 1x (real-time)

### DIFF
--- a/android/app/src/main/java/com/calc/emulator/MainActivity.kt
+++ b/android/app/src/main/java/com/calc/emulator/MainActivity.kt
@@ -112,7 +112,7 @@ fun EmulatorScreen(emulator: EmulatorBridge) {
     var isLcdOn by remember { mutableStateOf(true) }
 
     // Speed control (1x = 800K cycles, adjustable 1-10x)
-    var speedMultiplier by remember { mutableStateOf(2f) } // Default 2x for CEmu
+    var speedMultiplier by remember { mutableStateOf(1f) } // Default 1x (real-time)
 
     // Framebuffer bitmap
     val bitmap = remember {


### PR DESCRIPTION
## Summary
- Change default emulation speed from 2x to 1x (800K cycles per frame)
- Provides real-time emulation by default
- Speed slider still allows adjustment from 1-10x

## Test plan
- [ ] Launch Android app
- [ ] Verify speed slider shows 1x by default
- [ ] Verify calculator runs at real-time speed

🤖 Generated with [Claude Code](https://claude.com/claude-code)