### PR TITLE
feat: Add CEmu test tools for parity comparison

### DIFF
--- a/tools/cemu-test/.gitignore
+++ b/tools/cemu-test/.gitignore
@@ -1,0 +1,13 @@
+# Built binaries
+parity_check
+trace_gen
+test_cemu
+test_wrapper
+
+# Object files and libraries
+*.o
+*.a
+
+# Output files
+*.ppm
+*.png

--- a/tools/cemu-test/Makefile
+++ b/tools/cemu-test/Makefile
@@ -1,0 +1,73 @@
+# CEmu Test Tools
+#
+# Test tools for comparing CEmu behavior with our Rust emulator.
+#
+# Prerequisites:
+#   1. Clone CEmu into cemu-ref/:
+#      git clone https://github.com/CE-Programming/CEmu.git cemu-ref
+#
+#   2. Build CEmu core library:
+#      cd cemu-ref/core && make
+#
+#   3. Have a TI-84 Plus CE ROM file (not included, obtain legally)
+#
+# Build:
+#   make              - Build all tools
+#   make parity_check - Build parity checker only
+#   make trace_gen    - Build trace generator only
+#   make clean        - Remove built files
+#
+# Usage:
+#   ./parity_check [rom_path] [-m max_cycles]
+#   ./trace_gen <rom_path> [-n steps] [-o output]
+
+# Path to CEmu (cloned at repo root)
+CEMU_DIR = ../../cemu-ref
+
+CC = gcc
+CFLAGS = -Wall -Wextra -O2 -std=gnu11 -I$(CEMU_DIR)/core
+LDFLAGS = -L$(CEMU_DIR)/core -lcemucore
+
+# Main tools
+TARGETS = trace_gen parity_check
+
+all: check-cemu $(TARGETS)
+
+# Verify CEmu is set up
+check-cemu:
+	@if [ ! -f $(CEMU_DIR)/core/libcemucore.a ]; then \
+		echo "Error: CEmu core library not found."; \
+		echo "Please run: cd $(CEMU_DIR)/core && make"; \
+		exit 1; \
+	fi
+
+# CPU trace generator for parity comparison
+# Usage: ./trace_gen <rom> [-n steps] [-o output]
+trace_gen: trace_gen.c $(CEMU_DIR)/core/libcemucore.a
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+# Parity check tool - RTC timing, MathPrint, state comparison
+# Usage: ./parity_check [rom] [-v] [-m cycles]
+parity_check: parity_check.c $(CEMU_DIR)/core/libcemucore.a
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+# Wrapper library for external integration (JNI, FFI, etc.)
+libcemu_wrapper.a: cemu_wrapper.o
+	ar rcs $@ $^
+
+cemu_wrapper.o: cemu_wrapper.c cemu_wrapper.h
+	$(CC) $(CFLAGS) -c $< -o $@
+
+# Legacy tools (kept for reference)
+legacy: test_cemu test_wrapper
+
+test_cemu: test_cemu.c $(CEMU_DIR)/core/libcemucore.a
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+test_wrapper: test_wrapper.c cemu_wrapper.c cemu_wrapper.h $(CEMU_DIR)/core/libcemucore.a
+	$(CC) $(CFLAGS) test_wrapper.c cemu_wrapper.c -o $@ $(LDFLAGS)
+
+clean:
+	rm -f $(TARGETS) test_cemu test_wrapper *.ppm *.o *.a
+
+.PHONY: all clean legacy check-cemu

--- a/tools/cemu-test/README.md
+++ b/tools/cemu-test/README.md
@@ -1,0 +1,156 @@
+# CEmu Test Tools
+
+Test tools for comparing CEmu (reference emulator) behavior with our Rust TI-84 Plus CE emulator. These tools help verify parity between the two implementations.
+
+## Prerequisites
+
+### 1. Clone CEmu
+
+Clone the CEmu repository into `cemu-ref/` at the project root:
+
+```bash
+cd /path/to/calc
+git clone https://github.com/CE-Programming/CEmu.git cemu-ref
+```
+
+### 2. Build CEmu Core Library
+
+Build the CEmu core library (headless, no Qt GUI):
+
+```bash
+cd cemu-ref/core
+make
+```
+
+This creates `libcemucore.a` which our test tools link against.
+
+### 3. Obtain a ROM
+
+You need a TI-84 Plus CE ROM file. This is copyrighted and not included in the repository.
+Place it at the project root as `TI-84 CE.rom` or specify the path when running tools.
+
+## Building the Test Tools
+
+```bash
+cd tools/cemu-test
+make
+```
+
+This builds:
+- `parity_check` - RTC timing and MathPrint flag checker
+- `trace_gen` - CPU instruction trace generator
+
+## Tools
+
+### parity_check
+
+Checks RTC timing, MathPrint flag, and key emulator state at cycle milestones.
+Useful for verifying our emulator matches CEmu's behavior during boot.
+
+```bash
+# Run with defaults (60M cycles, ROM at ../../TI-84 CE.rom)
+./parity_check
+
+# Specify ROM path and max cycles
+./parity_check /path/to/rom.rom -m 100000000
+
+# Verbose mode
+./parity_check -v
+```
+
+**Output example:**
+```
+=== CEmu Parity Check ===
+
+Cycle(M)  | RTC Ctrl | RTC Status | loadTicks | mode | MathPrint | PC
+----------|----------|------------|-----------|------|-----------|--------
+       27 | 0x40     | 0xF8       |       255 |    1 | 0x00 Classic   | 0x0101A1
+       28 | 0x40     | 0xF8       |       255 |    1 | 0x00 Classic   | 0x00730C
+```
+
+**Key addresses monitored:**
+- `0xD000C4` - MathPrint flag (bit 5: 1=MathPrint, 0=Classic)
+- `0xF80020` - RTC control register (bit 6: load in progress)
+- `0xF80040` - RTC load status (0x00=complete, 0xF8=all pending)
+
+### trace_gen
+
+Generates CPU instruction traces in the same format as our Rust emulator for direct comparison.
+
+```bash
+# Generate 1M step trace to stdout
+./trace_gen ../../TI-84\ CE.rom
+
+# Generate 100K step trace to file
+./trace_gen ../../TI-84\ CE.rom -n 100000 -o cemu_trace.txt
+```
+
+**Output format (space-separated):**
+```
+step cycles PC SP AF BC DE HL IX IY ADL IFF1 IFF2 IM HALT opcode
+```
+
+### Comparing Traces
+
+To compare CEmu and Rust emulator traces:
+
+```bash
+# Generate CEmu trace
+./trace_gen ../../TI-84\ CE.rom -n 10000 -o cemu_trace.txt
+
+# Generate Rust trace (from core/ directory)
+cargo run --release --example debug -- trace -n 10000 > rust_trace.txt
+
+# Compare
+diff cemu_trace.txt rust_trace.txt | head -50
+```
+
+## Wrapper Library
+
+For external integration (JNI, FFI), build the wrapper library:
+
+```bash
+make libcemu_wrapper.a
+```
+
+See `cemu_wrapper.h` for the API.
+
+## Troubleshooting
+
+### "CEmu core library not found"
+
+Make sure you've built the CEmu core library:
+```bash
+cd ../../cemu-ref/core
+make
+```
+
+### "ROM not found"
+
+Specify the correct path to your ROM file:
+```bash
+./parity_check /path/to/your/TI-84\ CE.rom
+```
+
+### Compilation errors about missing headers
+
+Ensure CEmu is cloned to the correct location:
+```bash
+ls ../../cemu-ref/core/emu.h  # Should exist
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `parity_check.c` | RTC/MathPrint parity checker |
+| `trace_gen.c` | CPU trace generator |
+| `cemu_wrapper.c/h` | Wrapper library for external use |
+| `test_cemu.c` | Basic CEmu test |
+| `test_wrapper.c` | Wrapper API test |
+| `Makefile` | Build system |
+
+## Related Documentation
+
+- [docs/findings.md](../../docs/findings.md) - Investigation findings including RTC timing
+- [CLAUDE.md](../../CLAUDE.md) - CEmu reference section with memory map and port details

--- a/tools/cemu-test/cemu_wrapper.c
+++ b/tools/cemu-test/cemu_wrapper.c
@@ -1,0 +1,241 @@
+/*
+ * CEmu Wrapper - implements our emulator API using CEmu backend
+ *
+ * CEmu uses global state, so this wrapper creates a "virtual" instance
+ * that just wraps the global state. Only one instance can be active.
+ */
+#include "cemu_wrapper.h"
+#include "../../cemu-ref/core/emu.h"
+#include "../../cemu-ref/core/asic.h"
+#include "../../cemu-ref/core/lcd.h"
+#include "../../cemu-ref/core/mem.h"
+#include "../../cemu-ref/core/cpu.h"
+#include "../../cemu-ref/core/keypad.h"
+#include "../../cemu-ref/core/schedule.h"
+#include "../../cemu-ref/core/backlight.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+#include <stdbool.h>
+
+// Tick conversion: at 48MHz, 160 base ticks = 1 CPU cycle
+#define TICKS_PER_CYCLE 160
+
+// Wrapper state
+struct WrapEmu {
+    bool initialized;
+    uint32_t framebuffer[LCD_WIDTH * LCD_HEIGHT];
+};
+
+// Singleton - CEmu only supports one instance
+static struct WrapEmu* g_instance = NULL;
+static wrap_log_cb_t g_log_callback = NULL;
+static char g_log_buffer[4096];
+
+// GUI callback implementations (required by CEmu core)
+void gui_console_clear(void) {
+    // No-op
+}
+
+void gui_console_printf(const char *format, ...) {
+    if (g_log_callback) {
+        va_list args;
+        va_start(args, format);
+        vsnprintf(g_log_buffer, sizeof(g_log_buffer), format, args);
+        va_end(args);
+        g_log_callback(g_log_buffer);
+    }
+}
+
+void gui_console_err_printf(const char *format, ...) {
+    if (g_log_callback) {
+        va_list args;
+        va_start(args, format);
+        vsnprintf(g_log_buffer, sizeof(g_log_buffer), format, args);
+        va_end(args);
+        g_log_callback(g_log_buffer);
+    }
+}
+
+asic_rev_t gui_handle_reset(const boot_ver_t* boot_ver, asic_rev_t loaded_rev,
+                            asic_rev_t default_rev, emu_device_t device, bool* python) {
+    (void)boot_ver;
+    (void)device;
+    (void)python;
+    if (loaded_rev != ASIC_REV_AUTO) {
+        return loaded_rev;
+    }
+    return default_rev;
+}
+
+#ifdef DEBUG_SUPPORT
+void gui_debug_open(int reason, uint32_t data) {
+    (void)reason;
+    (void)data;
+}
+void gui_debug_close(void) {}
+#endif
+
+// API Implementation
+
+WrapEmu* wrap_emu_create(void) {
+    if (g_instance != NULL) {
+        // Only one instance allowed
+        return NULL;
+    }
+
+    g_instance = (struct WrapEmu*)calloc(1, sizeof(struct WrapEmu));
+    if (!g_instance) {
+        return NULL;
+    }
+
+    g_instance->initialized = false;
+    return g_instance;
+}
+
+void wrap_emu_destroy(WrapEmu* emu) {
+    if (emu && emu == g_instance) {
+        if (emu->initialized) {
+            asic_free();
+        }
+        free(emu);
+        g_instance = NULL;
+    }
+}
+
+void wrap_emu_set_log_callback(wrap_log_cb_t cb) {
+    g_log_callback = cb;
+}
+
+int wrap_emu_load_rom(WrapEmu* emu, const uint8_t* data, size_t len) {
+    if (!emu || emu != g_instance || !data || len == 0) {
+        return -1;
+    }
+
+    // CEmu's emu_load expects a file path, so we need to write to a temp file
+    const char* temp_path = "/tmp/cemu_temp_rom.rom";
+    FILE* f = fopen(temp_path, "wb");
+    if (!f) {
+        return -2;
+    }
+
+    if (fwrite(data, 1, len, f) != len) {
+        fclose(f);
+        return -3;
+    }
+    fclose(f);
+
+    // Load via CEmu
+    emu_state_t state = emu_load(EMU_DATA_ROM, temp_path);
+    if (state != EMU_STATE_VALID) {
+        return -4;
+    }
+
+    // Set run rate to 48MHz
+    emu_set_run_rate(48000000);
+
+    emu->initialized = true;
+    return 0;
+}
+
+void wrap_emu_reset(WrapEmu* emu) {
+    if (emu && emu == g_instance && emu->initialized) {
+        asic_reset();
+    }
+}
+
+int wrap_emu_run_cycles(WrapEmu* emu, int cycles) {
+    if (!emu || emu != g_instance || !emu->initialized || cycles <= 0) {
+        return 0;
+    }
+
+    // Convert cycles to ticks
+    uint64_t ticks = (uint64_t)cycles * TICKS_PER_CYCLE;
+
+    // Run emulation
+    emu_run(ticks);
+
+    return cycles;
+}
+
+const uint32_t* wrap_emu_framebuffer(const WrapEmu* emu, int* w, int* h) {
+    if (!emu || emu != g_instance || !emu->initialized) {
+        if (w) *w = 0;
+        if (h) *h = 0;
+        return NULL;
+    }
+
+    if (w) *w = LCD_WIDTH;
+    if (h) *h = LCD_HEIGHT;
+
+    // Copy framebuffer (emu_lcd_drawframe modifies buffer, so cast away const)
+    emu_lcd_drawframe(((struct WrapEmu*)emu)->framebuffer);
+
+    return emu->framebuffer;
+}
+
+void wrap_emu_set_key(WrapEmu* emu, int row, int col, int down) {
+    if (!emu || emu != g_instance || !emu->initialized) {
+        return;
+    }
+
+    emu_keypad_event((unsigned int)row, (unsigned int)col, down != 0);
+}
+
+uint8_t wrap_emu_get_backlight(const WrapEmu* emu) {
+    if (!emu || emu != g_instance || !emu->initialized) {
+        return 0;
+    }
+
+    return backlight.brightness;
+}
+
+int wrap_emu_is_lcd_on(const WrapEmu* emu) {
+    if (!emu || emu != g_instance || !emu->initialized) {
+        return 0;
+    }
+
+    // Check LCD control register bit 0 (enable)
+    return (lcd.control & 1) ? 1 : 0;
+}
+
+size_t wrap_emu_save_state_size(const WrapEmu* emu) {
+    (void)emu;
+    // CEmu save state is complex, estimate a large size
+    // In practice, would need to implement proper serialization
+    return 0; // Not implemented
+}
+
+int wrap_emu_save_state(const WrapEmu* emu, uint8_t* out, size_t cap) {
+    (void)emu;
+    (void)out;
+    (void)cap;
+    // Not implemented - would need to serialize CEmu state to buffer
+    return -1;
+}
+
+int wrap_emu_load_state(WrapEmu* emu, const uint8_t* data, size_t len) {
+    (void)emu;
+    (void)data;
+    (void)len;
+    // Not implemented - would need to deserialize CEmu state from buffer
+    return -1;
+}
+
+// Debug functions
+
+uint32_t wrap_emu_get_pc(const WrapEmu* emu) {
+    if (!emu || emu != g_instance || !emu->initialized) {
+        return 0;
+    }
+    return cpu.registers.PC;
+}
+
+uint8_t wrap_emu_peek_byte(const WrapEmu* emu, uint32_t addr) {
+    if (!emu || emu != g_instance || !emu->initialized) {
+        return 0;
+    }
+    return mem_peek_byte(addr);
+}

--- a/tools/cemu-test/cemu_wrapper.h
+++ b/tools/cemu-test/cemu_wrapper.h
@@ -1,0 +1,61 @@
+/*
+ * CEmu Wrapper - implements our emulator API using CEmu backend
+ *
+ * This provides API compatibility so we can swap between our Rust
+ * implementation and CEmu for debugging/comparison.
+ *
+ * Note: Functions are prefixed with "wrap_" to avoid conflicts with
+ * CEmu's own emu_* functions.
+ */
+#ifndef CEMU_WRAPPER_H
+#define CEMU_WRAPPER_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct WrapEmu WrapEmu;
+typedef void (*wrap_log_cb_t)(const char* message);
+
+// Lifecycle
+WrapEmu* wrap_emu_create(void);
+void wrap_emu_destroy(WrapEmu* emu);
+void wrap_emu_set_log_callback(wrap_log_cb_t cb);
+
+// ROM loading (bytes only)
+int  wrap_emu_load_rom(WrapEmu* emu, const uint8_t* data, size_t len); // 0 ok, else error code
+
+void wrap_emu_reset(WrapEmu* emu);
+
+// Execution
+int  wrap_emu_run_cycles(WrapEmu* emu, int cycles); // returns executed cycles
+
+// Framebuffer (owned by wrapper), ARGB8888
+const uint32_t* wrap_emu_framebuffer(const WrapEmu* emu, int* w, int* h);
+
+// Input
+void wrap_emu_set_key(WrapEmu* emu, int row, int col, int down);
+
+// Backlight
+uint8_t wrap_emu_get_backlight(const WrapEmu* emu); // 0-255, 0 = off (screen black)
+
+// LCD state - 1 if LCD is on (show content), 0 if LCD is off (show black)
+int wrap_emu_is_lcd_on(const WrapEmu* emu);
+
+// Optional save state (buffer-based)
+size_t wrap_emu_save_state_size(const WrapEmu* emu);
+int    wrap_emu_save_state(const WrapEmu* emu, uint8_t* out, size_t cap); // bytes written or <0
+int    wrap_emu_load_state(WrapEmu* emu, const uint8_t* data, size_t len);
+
+// Debug functions specific to CEmu wrapper
+uint32_t wrap_emu_get_pc(const WrapEmu* emu);
+uint8_t wrap_emu_peek_byte(const WrapEmu* emu, uint32_t addr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CEMU_WRAPPER_H

--- a/tools/cemu-test/parity_check.c
+++ b/tools/cemu-test/parity_check.c
@@ -1,0 +1,210 @@
+/*
+ * CEmu Parity Check Tool
+ *
+ * Comprehensive tool for comparing CEmu state with our Rust emulator.
+ * Checks RTC timing, MathPrint flag, and other key state at cycle milestones.
+ *
+ * Usage: ./parity_check [rom_path] [-v] [-m cycles]
+ *   rom_path   Path to TI-84 CE ROM (default: ../../TI-84 CE.rom)
+ *   -v         Verbose mode (more detailed output)
+ *   -m cycles  Maximum cycles to run (default: 60M)
+ *
+ * Key addresses monitored:
+ *   0xD000C4 - MathPrint flag (bit 5: 1=MathPrint, 0=Classic)
+ *   0xF80020 - RTC control register (bit 6: load in progress)
+ *   0xF80040 - RTC load status (0x00=complete, 0xF8=all pending)
+ *
+ * Expected behavior:
+ *   - RTC load stays pending (0xF8) until ~24M cycles at 48MHz
+ *   - MathPrint flag should be set (0x20) after boot completes
+ */
+
+#include "../../cemu-ref/core/emu.h"
+#include "../../cemu-ref/core/asic.h"
+#include "../../cemu-ref/core/mem.h"
+#include "../../cemu-ref/core/cpu.h"
+#include "../../cemu-ref/core/realclock.h"
+#include "../../cemu-ref/core/lcd.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+
+/* GUI stubs required by CEmu */
+void gui_console_clear(void) {}
+void gui_console_printf(const char *format, ...) { (void)format; }
+void gui_console_err_printf(const char *format, ...) { (void)format; }
+asic_rev_t gui_handle_reset(const boot_ver_t* b, asic_rev_t l, asic_rev_t d,
+                             emu_device_t e, bool* p) {
+    (void)b; (void)e; (void)p;
+    return (l != ASIC_REV_AUTO) ? l : d;
+}
+#ifdef DEBUG_SUPPORT
+void gui_debug_open(int r, uint32_t d) { (void)r; (void)d; }
+void gui_debug_close(void) {}
+#endif
+
+/* Key memory addresses */
+#define MATHPRINT_ADDR  0xD000C4
+#define RTC_CONTROL     0xF80020
+#define RTC_LOAD_STATUS 0xF80040
+
+/* Default cycle milestones to check */
+static uint32_t default_milestones[] = {
+    1000000,   /*  1M - Very early boot */
+    5000000,   /*  5M - Early boot */
+    10000000,  /* 10M - Boot progress */
+    20000000,  /* 20M - Before first RTC load trigger */
+    25000000,  /* 25M - First load should be pending */
+    26000000,  /* 26M - Fine granularity */
+    27000000,  /* 27M - Poll loop region */
+    27500000,  /* 27.5M - Where we found 0xF8 status */
+    28000000,  /* 28M - Fine granularity */
+    29000000,  /* 29M - Load may complete here */
+    30000000,  /* 30M - After initial load */
+    40000000,  /* 40M - Mid boot */
+    50000000,  /* 50M - Late boot */
+    60000000,  /* 60M - Should be near home screen */
+};
+#define NUM_DEFAULT_MILESTONES (sizeof(default_milestones) / sizeof(default_milestones[0]))
+
+void print_header(void) {
+    printf("=== CEmu Parity Check ===\n\n");
+    printf("Cycle(M)  | RTC Ctrl | RTC Status | loadTicks | mode | MathPrint | PC\n");
+    printf("----------|----------|------------|-----------|------|-----------|--------\n");
+}
+
+void print_state(uint32_t cycle_millions) {
+    /* Read RTC state directly from struct (more reliable than mem_peek) */
+    uint8_t rtc_ctrl = rtc.control;
+    int8_t ticks = rtc.loadTicksProcessed;
+
+    /* Compute load status same way as rtc_read() does for offset 0x40 */
+    uint8_t rtc_status;
+    if (ticks >= 51) {  /* LOAD_TOTAL_TICKS */
+        rtc_status = 0x00;  /* Load complete */
+    } else {
+        /* Bits set indicate load still in progress for each field */
+        rtc_status = 8 | ((ticks < 9) ? 0x10 : 0)    /* sec */
+                       | ((ticks < 17) ? 0x20 : 0)   /* min */
+                       | ((ticks < 25) ? 0x40 : 0)   /* hour */
+                       | ((ticks < 41) ? 0x80 : 0);  /* day */
+    }
+
+    uint8_t mathprint = mem_peek_byte(MATHPRINT_ADDR);
+    const char* mp_str = (mathprint & 0x20) ? "MathPrint" : "Classic  ";
+
+    printf("%9u | 0x%02X     | 0x%02X       | %9d | %4d | 0x%02X %s | 0x%06X\n",
+           cycle_millions,
+           rtc_ctrl,
+           rtc_status,
+           rtc.loadTicksProcessed,
+           rtc.mode,
+           mathprint,
+           mp_str,
+           cpu.registers.PC);
+}
+
+void print_summary(void) {
+    uint8_t mathprint = mem_peek_byte(MATHPRINT_ADDR);
+
+    printf("\n=== Summary ===\n");
+    printf("Final MathPrint byte: 0x%02X\n", mathprint);
+    printf("MathPrint mode: %s\n", (mathprint & 0x20) ? "ENABLED (MathPrint)" : "DISABLED (Classic)");
+    printf("Final PC: 0x%06X\n", cpu.registers.PC);
+    printf("Total cycles: %llu\n", (unsigned long long)cpu.cycles);
+
+    /* Check expected state */
+    printf("\n=== Parity Checks ===\n");
+    if (mathprint & 0x20) {
+        printf("[PASS] MathPrint flag is set\n");
+    } else {
+        printf("[FAIL] MathPrint flag is NOT set (expected MathPrint mode)\n");
+    }
+}
+
+void save_screenshot(const char* filename) {
+    uint32_t fb[320 * 240];
+    emu_lcd_drawframe(fb);
+
+    FILE* f = fopen(filename, "wb");
+    if (!f) return;
+
+    fprintf(f, "P6\n320 240\n255\n");
+    for (int i = 0; i < 320 * 240; i++) {
+        fputc((fb[i] >> 16) & 0xFF, f);
+        fputc((fb[i] >> 8) & 0xFF, f);
+        fputc(fb[i] & 0xFF, f);
+    }
+    fclose(f);
+    printf("Screenshot saved: %s\n", filename);
+}
+
+int main(int argc, char* argv[]) {
+    const char* rom_path = "../../TI-84 CE.rom";
+    bool verbose = false;
+    uint64_t max_cycles = 60000000;
+
+    /* Parse arguments */
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "-v") == 0) {
+            verbose = true;
+        } else if (strcmp(argv[i], "-m") == 0 && i + 1 < argc) {
+            max_cycles = strtoull(argv[++i], NULL, 10);
+        } else if (argv[i][0] != '-') {
+            rom_path = argv[i];
+        }
+    }
+
+    /* Load ROM */
+    FILE* f = fopen(rom_path, "rb");
+    if (!f) {
+        fprintf(stderr, "ROM not found: %s\n", rom_path);
+        return 1;
+    }
+
+    fseek(f, 0, SEEK_END);
+    size_t sz = ftell(f);
+    rewind(f);
+
+    uint8_t* rom = malloc(sz);
+    fread(rom, 1, sz, f);
+    fclose(f);
+
+    /* Write to temp file for CEmu */
+    f = fopen("/tmp/parity_check.rom", "wb");
+    fwrite(rom, 1, sz, f);
+    fclose(f);
+    free(rom);
+
+    if (emu_load(EMU_DATA_ROM, "/tmp/parity_check.rom") != EMU_STATE_VALID) {
+        fprintf(stderr, "Failed to load ROM\n");
+        return 1;
+    }
+
+    emu_set_run_rate(48000000);
+
+    print_header();
+
+    /* Run to each milestone */
+    size_t milestone_idx = 0;
+    while (milestone_idx < NUM_DEFAULT_MILESTONES &&
+           default_milestones[milestone_idx] <= max_cycles) {
+
+        uint32_t target = default_milestones[milestone_idx];
+
+        while (cpu.cycles < target) {
+            emu_run(100000);
+        }
+
+        print_state(target / 1000000);
+        milestone_idx++;
+    }
+
+    print_summary();
+    save_screenshot("parity_check_final.ppm");
+
+    asic_free();
+    return 0;
+}

--- a/tools/cemu-test/test_cemu.c
+++ b/tools/cemu-test/test_cemu.c
@@ -1,0 +1,157 @@
+/*
+ * Test program for CEmu core library
+ * Implements GUI stubs and tests ROM loading/execution
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+#include <stdint.h>
+
+// CEmu headers
+#include "../../cemu-ref/core/emu.h"
+#include "../../cemu-ref/core/asic.h"
+#include "../../cemu-ref/core/lcd.h"
+#include "../../cemu-ref/core/mem.h"
+#include "../../cemu-ref/core/cpu.h"
+#include "../../cemu-ref/core/schedule.h"
+
+// GUI callback implementations (required by CEmu core)
+void gui_console_clear(void) {
+    // No-op for testing
+}
+
+void gui_console_printf(const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+    vfprintf(stdout, format, args);
+    va_end(args);
+}
+
+void gui_console_err_printf(const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+    vfprintf(stderr, format, args);
+    va_end(args);
+}
+
+asic_rev_t gui_handle_reset(const boot_ver_t* boot_ver, asic_rev_t loaded_rev,
+                            asic_rev_t default_rev, emu_device_t device, bool* python) {
+    (void)boot_ver;
+    (void)device;
+    (void)python;
+    // Return the loaded revision, or default if auto
+    if (loaded_rev != ASIC_REV_AUTO) {
+        return loaded_rev;
+    }
+    return default_rev;
+}
+
+#ifdef DEBUG_SUPPORT
+void gui_debug_open(int reason, uint32_t data) {
+    (void)reason;
+    (void)data;
+}
+void gui_debug_close(void) {}
+#endif
+
+// Save LCD framebuffer as PPM image
+void save_lcd_ppm(const char* filename) {
+    uint32_t framebuffer[LCD_WIDTH * LCD_HEIGHT];
+    emu_lcd_drawframe(framebuffer);
+
+    FILE* f = fopen(filename, "wb");
+    if (!f) {
+        fprintf(stderr, "Failed to open %s for writing\n", filename);
+        return;
+    }
+
+    fprintf(f, "P6\n%d %d\n255\n", LCD_WIDTH, LCD_HEIGHT);
+    for (int i = 0; i < LCD_WIDTH * LCD_HEIGHT; i++) {
+        uint32_t pixel = framebuffer[i];
+        // ARGB8888 format
+        uint8_t r = (pixel >> 16) & 0xFF;
+        uint8_t g = (pixel >> 8) & 0xFF;
+        uint8_t b = pixel & 0xFF;
+        fputc(r, f);
+        fputc(g, f);
+        fputc(b, f);
+    }
+    fclose(f);
+    printf("Saved LCD to %s\n", filename);
+}
+
+int main(int argc, char* argv[]) {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <rom_file> [cycles]\n", argv[0]);
+        return 1;
+    }
+
+    const char* rom_path = argv[1];
+    uint64_t cycles = 70000000; // Default: 70M cycles (enough for boot)
+    if (argc >= 3) {
+        cycles = strtoull(argv[2], NULL, 10);
+    }
+
+    printf("Loading ROM: %s\n", rom_path);
+
+    // Load ROM
+    emu_state_t state = emu_load(EMU_DATA_ROM, rom_path);
+    if (state != EMU_STATE_VALID) {
+        fprintf(stderr, "Failed to load ROM (state=%d)\n", state);
+        return 1;
+    }
+
+    printf("ROM loaded successfully, device type: %d\n", get_device_type());
+
+    // Set run rate to 48MHz
+    if (!emu_set_run_rate(48000000)) {
+        fprintf(stderr, "Failed to set run rate\n");
+        return 1;
+    }
+
+    printf("Running %llu cycles...\n", (unsigned long long)cycles);
+
+    // CEmu uses ticks, not cycles. At 48MHz, 160 ticks = 1 cycle
+    // ticks = cycles * 160
+    uint64_t ticks = cycles * 160;
+
+    // Run in chunks to allow periodic screenshots
+    uint64_t chunk_size = 10000000 * 160; // 10M cycles per chunk
+    uint64_t ticks_run = 0;
+    int screenshot_num = 0;
+
+    while (ticks_run < ticks) {
+        uint64_t run_ticks = chunk_size;
+        if (ticks_run + run_ticks > ticks) {
+            run_ticks = ticks - ticks_run;
+        }
+
+        emu_run(run_ticks);
+        ticks_run += run_ticks;
+
+        printf("Progress: %llu / %llu cycles (%.1f%%)\n",
+               (unsigned long long)(ticks_run / 160),
+               (unsigned long long)cycles,
+               100.0 * ticks_run / ticks);
+
+        // Take periodic screenshots
+        if (screenshot_num < 5) {
+            char filename[64];
+            snprintf(filename, sizeof(filename), "cemu_screen_%d.ppm", screenshot_num++);
+            save_lcd_ppm(filename);
+        }
+    }
+
+    // Final screenshot
+    save_lcd_ppm("cemu_screen_final.ppm");
+
+    printf("Emulation complete!\n");
+    printf("Total cycles: %llu\n", (unsigned long long)sched_total_cycles());
+    printf("PC: 0x%06X\n", cpu.registers.PC);
+
+    // Cleanup
+    asic_free();
+
+    return 0;
+}

--- a/tools/cemu-test/test_wrapper.c
+++ b/tools/cemu-test/test_wrapper.c
@@ -1,0 +1,140 @@
+/*
+ * Test program for CEmu wrapper API
+ * Tests that our API works with CEmu backend
+ */
+#include "cemu_wrapper.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define LCD_WIDTH 320
+#define LCD_HEIGHT 240
+
+// Log callback
+void log_callback(const char* message) {
+    printf("%s", message);
+}
+
+// Save framebuffer as PPM
+void save_ppm(const uint32_t* fb, int w, int h, const char* filename) {
+    FILE* f = fopen(filename, "wb");
+    if (!f) {
+        fprintf(stderr, "Failed to open %s\n", filename);
+        return;
+    }
+
+    fprintf(f, "P6\n%d %d\n255\n", w, h);
+    for (int i = 0; i < w * h; i++) {
+        uint32_t pixel = fb[i];
+        uint8_t r = (pixel >> 16) & 0xFF;
+        uint8_t g = (pixel >> 8) & 0xFF;
+        uint8_t b = pixel & 0xFF;
+        fputc(r, f);
+        fputc(g, f);
+        fputc(b, f);
+    }
+    fclose(f);
+    printf("Saved: %s\n", filename);
+}
+
+int main(int argc, char* argv[]) {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <rom_file>\n", argv[0]);
+        return 1;
+    }
+
+    // Read ROM file into memory
+    FILE* f = fopen(argv[1], "rb");
+    if (!f) {
+        fprintf(stderr, "Failed to open ROM: %s\n", argv[1]);
+        return 1;
+    }
+
+    fseek(f, 0, SEEK_END);
+    size_t rom_size = ftell(f);
+    rewind(f);
+
+    uint8_t* rom_data = malloc(rom_size);
+    if (!rom_data) {
+        fprintf(stderr, "Failed to allocate ROM buffer\n");
+        fclose(f);
+        return 1;
+    }
+
+    if (fread(rom_data, 1, rom_size, f) != rom_size) {
+        fprintf(stderr, "Failed to read ROM\n");
+        free(rom_data);
+        fclose(f);
+        return 1;
+    }
+    fclose(f);
+
+    printf("ROM loaded: %zu bytes\n", rom_size);
+
+    // Set log callback
+    wrap_emu_set_log_callback(log_callback);
+
+    // Create emulator
+    WrapEmu* emu = wrap_emu_create();
+    if (!emu) {
+        fprintf(stderr, "Failed to create emulator\n");
+        free(rom_data);
+        return 1;
+    }
+    printf("Emulator created\n");
+
+    // Load ROM
+    int result = wrap_emu_load_rom(emu, rom_data, rom_size);
+    if (result != 0) {
+        fprintf(stderr, "Failed to load ROM: %d\n", result);
+        wrap_emu_destroy(emu);
+        free(rom_data);
+        return 1;
+    }
+    printf("ROM loaded into emulator\n");
+
+    // Run for 70M cycles (enough for boot)
+    int total_cycles = 70000000;
+    int chunk = 10000000;
+    int screenshot = 0;
+
+    for (int i = 0; i < total_cycles; i += chunk) {
+        int to_run = chunk;
+        if (i + to_run > total_cycles) {
+            to_run = total_cycles - i;
+        }
+
+        int executed = wrap_emu_run_cycles(emu, to_run);
+        printf("Executed %d cycles (total: %d/%d)\n", executed, i + executed, total_cycles);
+
+        // Get framebuffer and save screenshot
+        int w, h;
+        const uint32_t* fb = wrap_emu_framebuffer(emu, &w, &h);
+        if (fb && w > 0 && h > 0 && screenshot < 3) {
+            char filename[64];
+            snprintf(filename, sizeof(filename), "wrapper_screen_%d.ppm", screenshot++);
+            save_ppm(fb, w, h, filename);
+        }
+    }
+
+    // Final screenshot
+    int w, h;
+    const uint32_t* fb = wrap_emu_framebuffer(emu, &w, &h);
+    if (fb && w > 0 && h > 0) {
+        save_ppm(fb, w, h, "wrapper_screen_final.ppm");
+    }
+
+    // Debug info
+    printf("\nFinal state:\n");
+    printf("  PC: 0x%06X\n", wrap_emu_get_pc(emu));
+    printf("  MathPrint flag (0xD000C4): 0x%02X\n", wrap_emu_peek_byte(emu, 0xD000C4));
+    printf("  Backlight: %d\n", wrap_emu_get_backlight(emu));
+    printf("  LCD on: %d\n", wrap_emu_is_lcd_on(emu));
+
+    // Cleanup
+    wrap_emu_destroy(emu);
+    free(rom_data);
+
+    printf("\nTest complete!\n");
+    return 0;
+}

--- a/tools/cemu-test/trace_gen.c
+++ b/tools/cemu-test/trace_gen.c
@@ -1,0 +1,237 @@
+/*
+ * CEmu Trace Generator
+ * Generates CPU trace output in the same format as our Rust emulator for comparison
+ *
+ * Output format (space-separated):
+ *   step cycles PC SP AF BC DE HL IX IY ADL IFF1 IFF2 IM HALT opcode
+ */
+#include "../../cemu-ref/core/emu.h"
+#include "../../cemu-ref/core/asic.h"
+#include "../../cemu-ref/core/lcd.h"
+#include "../../cemu-ref/core/mem.h"
+#include "../../cemu-ref/core/cpu.h"
+#include "../../cemu-ref/core/keypad.h"
+#include "../../cemu-ref/core/schedule.h"
+#include "../../cemu-ref/core/backlight.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdbool.h>
+
+#define LCD_WIDTH 320
+#define LCD_HEIGHT 240
+
+// Silence CEmu console output
+void gui_console_clear(void) {}
+void gui_console_printf(const char *format, ...) { (void)format; }
+void gui_console_err_printf(const char *format, ...) { (void)format; }
+
+asic_rev_t gui_handle_reset(const boot_ver_t* boot_ver, asic_rev_t loaded_rev,
+                            asic_rev_t default_rev, emu_device_t device, bool* python) {
+    (void)boot_ver; (void)device; (void)python;
+    return (loaded_rev != ASIC_REV_AUTO) ? loaded_rev : default_rev;
+}
+
+#ifdef DEBUG_SUPPORT
+void gui_debug_open(int reason, uint32_t data) { (void)reason; (void)data; }
+void gui_debug_close(void) {}
+#endif
+
+void log_trace_line(FILE* out, uint64_t step, uint64_t cycles) {
+    // Get register values
+    uint32_t pc = cpu.registers.PC;
+    uint32_t sp = cpu.ADL ? cpu.registers.SPL : cpu.registers.SPS;
+    uint16_t af = cpu.registers.AF;
+    uint32_t bc = cpu.registers.BC;
+    uint32_t de = cpu.registers.DE;
+    uint32_t hl = cpu.registers.HL;
+    uint32_t ix = cpu.registers.IX;
+    uint32_t iy = cpu.registers.IY;
+    int adl = cpu.ADL ? 1 : 0;
+    int iff1 = cpu.IEF1 ? 1 : 0;
+    int iff2 = cpu.IEF2 ? 1 : 0;
+    int im = cpu.IM;
+    int halted = cpu.halted ? 1 : 0;
+
+    // Read opcode bytes at PC
+    uint8_t op1 = mem_peek_byte(pc);
+    uint8_t op2 = mem_peek_byte(pc + 1);
+    uint8_t op3 = mem_peek_byte(pc + 2);
+    uint8_t op4 = mem_peek_byte(pc + 3);
+
+    // Format opcode string (match Rust format)
+    char op_str[16];
+    if (op1 == 0xDD || op1 == 0xFD) {
+        if (op2 == 0xCB) {
+            snprintf(op_str, sizeof(op_str), "%02X%02X%02X%02X", op1, op2, op3, op4);
+        } else {
+            snprintf(op_str, sizeof(op_str), "%02X%02X", op1, op2);
+        }
+    } else if (op1 == 0xED || op1 == 0xCB) {
+        snprintf(op_str, sizeof(op_str), "%02X%02X", op1, op2);
+    } else {
+        snprintf(op_str, sizeof(op_str), "%02X", op1);
+    }
+
+    // IM mode string (match Rust format)
+    const char* im_str;
+    switch (im) {
+        case 0: im_str = "Mode0"; break;
+        case 1: im_str = "Mode1"; break;
+        case 2: im_str = "Mode2"; break;
+        case 3: im_str = "Mode3"; break;
+        default: im_str = "Mode0"; break;
+    }
+
+    fprintf(out, "%06llu %08llu %06X %06X %04X %06X %06X %06X %06X %06X %d %d %d %s %d %s\n",
+            (unsigned long long)step,
+            (unsigned long long)cycles,
+            pc, sp, af, bc, de, hl, ix, iy,
+            adl, iff1, iff2, im_str, halted, op_str);
+}
+
+void save_ppm(const uint32_t* fb, int w, int h, const char* filename) {
+    FILE* f = fopen(filename, "wb");
+    if (!f) return;
+    fprintf(f, "P6\n%d %d\n255\n", w, h);
+    for (int i = 0; i < w * h; i++) {
+        uint32_t pixel = fb[i];
+        fputc((pixel >> 16) & 0xFF, f);
+        fputc((pixel >> 8) & 0xFF, f);
+        fputc(pixel & 0xFF, f);
+    }
+    fclose(f);
+}
+
+int main(int argc, char* argv[]) {
+    uint64_t max_steps = 1000000; // Default 1M steps
+    const char* rom_path = NULL;
+    const char* output_path = NULL;
+
+    // Parse arguments
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "-n") == 0 && i + 1 < argc) {
+            max_steps = strtoull(argv[++i], NULL, 10);
+        } else if (strcmp(argv[i], "-o") == 0 && i + 1 < argc) {
+            output_path = argv[++i];
+        } else if (!rom_path) {
+            rom_path = argv[i];
+        }
+    }
+
+    if (!rom_path) {
+        fprintf(stderr, "Usage: %s <rom_file> [-n steps] [-o output]\n", argv[0]);
+        fprintf(stderr, "  -n steps   Number of steps to trace (default: 1000000)\n");
+        fprintf(stderr, "  -o output  Output file (default: stdout)\n");
+        return 1;
+    }
+
+    // Read ROM
+    FILE* f = fopen(rom_path, "rb");
+    if (!f) {
+        fprintf(stderr, "Failed to open ROM: %s\n", rom_path);
+        return 1;
+    }
+
+    fseek(f, 0, SEEK_END);
+    size_t rom_size = ftell(f);
+    rewind(f);
+
+    uint8_t* rom_data = malloc(rom_size);
+    if (!rom_data || fread(rom_data, 1, rom_size, f) != rom_size) {
+        fprintf(stderr, "Failed to read ROM\n");
+        fclose(f);
+        return 1;
+    }
+    fclose(f);
+
+    // Write ROM to temp file for CEmu
+    const char* temp_path = "/tmp/cemu_trace_rom.rom";
+    f = fopen(temp_path, "wb");
+    if (!f || fwrite(rom_data, 1, rom_size, f) != rom_size) {
+        fprintf(stderr, "Failed to write temp ROM\n");
+        return 1;
+    }
+    fclose(f);
+    free(rom_data);
+
+    // Load ROM via CEmu
+    emu_state_t state = emu_load(EMU_DATA_ROM, temp_path);
+    if (state != EMU_STATE_VALID) {
+        fprintf(stderr, "Failed to load ROM in CEmu\n");
+        return 1;
+    }
+    emu_set_run_rate(48000000);
+
+    // Open output
+    FILE* out = stdout;
+    if (output_path) {
+        out = fopen(output_path, "w");
+        if (!out) {
+            fprintf(stderr, "Failed to open output: %s\n", output_path);
+            return 1;
+        }
+    }
+
+    fprintf(stderr, "=== CEmu Trace Generation (%llu steps) ===\n", (unsigned long long)max_steps);
+
+    uint64_t step = 0;
+    uint64_t total_base_ticks = 0;
+
+    // Log initial state (step 0, before any instruction executes)
+    log_trace_line(out, step, total_base_ticks);
+
+    // Use emu_run with minimal tick increments to detect each instruction
+    // At 48MHz, 160 base ticks = 1 CPU cycle
+    // Run 1 tick at a time for finest granularity
+    const uint64_t TICKS_PER_STEP = 1;
+
+    while (step < max_steps) {
+        uint32_t pc_before = cpu.registers.PC;
+        bool halted_before = cpu.halted;
+
+        // Run for 1 CPU cycle worth of base ticks
+        emu_run(TICKS_PER_STEP);
+        total_base_ticks += TICKS_PER_STEP;
+
+        // Detect instruction boundary: PC changed, or halted state changed
+        if (cpu.registers.PC != pc_before || cpu.halted != halted_before) {
+            step++;
+            // Log state after this instruction completes
+            log_trace_line(out, step, total_base_ticks);
+
+            if (step % 100000 == 0) {
+                fprintf(stderr, "Progress: %llu steps (%.1f%%)\n",
+                        (unsigned long long)step, 100.0 * step / max_steps);
+            }
+
+            // Log HALT transitions
+            if (cpu.halted && !halted_before) {
+                fprintf(stderr, "HALT at step %llu, PC=0x%06X\n",
+                        (unsigned long long)step, cpu.registers.PC);
+            }
+        }
+    }
+
+    if (out != stdout) {
+        fclose(out);
+    }
+
+    // Save final screenshot
+    uint32_t framebuffer[LCD_WIDTH * LCD_HEIGHT];
+    emu_lcd_drawframe(framebuffer);
+    save_ppm(framebuffer, LCD_WIDTH, LCD_HEIGHT, "cemu_trace_final.ppm");
+
+    fprintf(stderr, "\nTrace complete: %llu steps / %llu base ticks\n",
+            (unsigned long long)step, (unsigned long long)total_base_ticks);
+    fprintf(stderr, "Final PC: 0x%06X\n", cpu.registers.PC);
+    if (output_path) {
+        fprintf(stderr, "Saved to: %s\n", output_path);
+    }
+    fprintf(stderr, "Screenshot: cemu_trace_final.ppm\n");
+
+    asic_free();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add `parity_check` tool to verify RTC timing and MathPrint flag at cycle milestones
- Add `trace_gen` tool to generate CPU traces for direct comparison with Rust emulator
- Add `cemu_wrapper` library for external integration
- Include Makefile with CEmu path configuration and comprehensive README

## Tools

### parity_check
Checks RTC timing, MathPrint flag, and key emulator state at cycle milestones:
```
Cycle(M)  | RTC Ctrl | RTC Status | loadTicks | mode | MathPrint | PC
       27 | 0x40     | 0xF8       |       255 |    1 | 0x00 Classic   | 0x0101A1
```

### trace_gen
Generates CPU traces matching our Rust emulator format:
```
step cycles PC SP AF BC DE HL IX IY ADL IFF1 IFF2 IM HALT opcode
```

## Test plan
- [x] `parity_check` builds and runs, shows correct RTC timing (0xF8 at 27-30M cycles)
- [x] `trace_gen` builds and runs, outputs valid trace format
- [x] README documents setup and usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)