### PR TITLE
chore: Add gitignore patterns for build artifacts and debug scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,19 @@ Thumbs.db
 *.ppm
 *.png
 
+# iOS build artifacts
+/ios/cemu/build-device/
+/ios/cemu/build-simulator/
+
+# Debug/test example scripts (one-off debugging files)
+/core/examples/check_*.rs
+/core/examples/*_check.rs
+/core/examples/*_trace.rs
+/core/examples/*_debug.rs
+/core/examples/*_test.rs
+/core/examples/*_compare.rs
+/core/examples/find_*.rs
+/core/examples/trace_*.rs
+
 # Claude Code local settings
 .claude/


### PR DESCRIPTION
## Summary
- Add patterns for iOS build directories (`build-device/`, `build-simulator/`)
- Add patterns for one-off debug example scripts (`check_*.rs`, `*_trace.rs`, etc.)

## Test plan
- [x] Verified untracked files are now ignored via `git status`

🤖 Generated with [Claude Code](https://claude.ai/code)