### PR TITLE
docs: Update milestones with iOS, backend switching, and WASM targets

### DIFF
--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -180,17 +180,6 @@ cargo run --release --example debug -- compare <cemu_trace>  # Compare traces
 - VRAM base: 0xD40000
 - OS reaches idle state with interrupts enabled (EI + HALT)
 
-## Milestone 6: Persistence
-
-**Goal:** State survives app restarts.
-
-**Deliverables:**
-
-- [ ] Flash write/erase behavior
-- [ ] Save-state buffer APIs
-- [ ] Android save/load state
-- [ ] State persistence verified
-
 ## Milestone 6: Android Display Integration ✓
 
 **Goal:** Display emulator screen on Android device.
@@ -231,7 +220,30 @@ cargo run --release --example debug -- compare <cemu_trace>  # Compare traces
 - **CRITICAL**: TI-OS uses port I/O (port 0xA via IN/OUT) not memory-mapped writes, requiring both I/O paths to call any_key_check
 - **Expression parser initialization**: First key press after boot auto-injects ENTER to dismiss boot screen and initialize TI-OS parser state (see findings.md)
 
-## Milestone 7: Persistence
+## Milestone 7: iOS App ✓
+
+**Goal:** Port emulator to iOS platform.
+
+**Deliverables:**
+
+- [x] iOS app builds and runs with Swift/SwiftUI
+- [x] CEmu backend integration
+- [x] Rust backend integration
+- [x] Runtime backend switching between Rust and CEmu
+- [x] Swipe-to-open gesture for menu (replaced menu button)
+- [x] State persistence for Rust emulator backend
+
+## Milestone 8: Android Backend Switching ✓
+
+**Goal:** Support multiple emulator backends on Android.
+
+**Deliverables:**
+
+- [x] CEmu backend integration
+- [x] Runtime backend switching between Rust and CEmu
+- [x] Backend selection UI
+
+## Milestone 9: Persistence (In Progress)
 
 **Goal:** State survives app restarts.
 
@@ -239,12 +251,28 @@ cargo run --release --example debug -- compare <cemu_trace>  # Compare traces
 
 - [ ] Flash write/erase behavior
 - [ ] Save-state buffer APIs
+- [x] iOS save/load state (Rust backend)
 - [ ] Android save/load state
-- [ ] State persistence verified
+- [ ] State persistence verified on both platforms
 
-## Milestone 8: Android Polish
+## Milestone 10: Web App (WASM)
 
-**Goal:** Production-ready Android app.
+**Goal:** Run emulator in web browser via WebAssembly.
+
+**Deliverables:**
+
+- [ ] Rust core compiles to WASM target
+- [ ] CEmu backend compiles to WASM (via Emscripten)
+- [ ] JavaScript/TypeScript bindings for emulator API
+- [ ] Web UI with canvas rendering
+- [ ] Keypad input handling (keyboard + touch)
+- [ ] Runtime backend switching in browser
+- [ ] ROM file loading via file picker
+- [ ] State persistence via IndexedDB/localStorage
+
+## Milestone 11: Polish
+
+**Goal:** Production-ready apps on all platforms.
 
 **Deliverables:**
 
@@ -252,3 +280,4 @@ cargo run --release --example debug -- compare <cemu_trace>  # Compare traces
 - [ ] Speed toggle (normal/turbo)
 - [ ] Debug overlay (optional)
 - [ ] Accurate keypad layout
+- [ ] Android state persistence


### PR DESCRIPTION
## Summary
- Fix duplicate milestone numbering (two Milestone 6s, duplicate Persistence sections)
- Add Milestone 7: iOS App ✓ (SwiftUI, dual backends, swipe gesture, state persistence)
- Add Milestone 8: Android Backend Switching ✓
- Update Milestone 9: Persistence - mark iOS save/load as complete
- Add Milestone 10: Web App (WASM) for both Rust and CEmu backends
- Renumber Polish to Milestone 11

## Test plan
- [x] Verify markdown renders correctly
- [x] Check milestone numbering is sequential

🤖 Generated with [Claude Code](https://claude.com/claude-code)