### PR TITLE
feat: Save flash memory in Rust backend state

### DIFF
--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -251,6 +251,15 @@ impl Flash {
         &self.data
     }
 
+    /// Load flash data from save state
+    pub fn load_data(&mut self, data: &[u8]) {
+        let len = data.len().min(addr::FLASH_SIZE);
+        self.data[..len].copy_from_slice(&data[..len]);
+        self.initialized = true;
+        self.command = FlashCommand::None;
+        self.write_state = FlashWriteState::Idle;
+    }
+
     /// Reset flash to erased state
     pub fn reset(&mut self) {
         self.data.fill(0xFF);

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -250,8 +250,8 @@ cargo run --release --example debug -- compare <cemu_trace>  # Compare traces
 **Deliverables:**
 
 - [ ] Flash write/erase behavior
-- [ ] Rust backend: Save flash in state (currently RAM-only; needed for user programs)
-- [x] Save-state buffer APIs (Rust: ~416KB RAM-only, CEmu: ~4.5MB with flash)
+- [x] Rust backend: Save flash in state (now includes 4MB flash)
+- [x] Save-state buffer APIs (Rust: ~4.5MB with flash, CEmu: ~4.5MB)
 - [x] iOS save/load state (Rust backend)
 - [x] iOS save/load state (CEmu backend)
 - [ ] Android save/load state


### PR DESCRIPTION
## Summary
- Add `load_data()` method to Flash for state restoration
- Bump `STATE_VERSION` from 1 to 2 (format includes flash now)
- Include 4MB flash in save/load state operations
- State size now ~4.5MB matching CEmu backend

This enables persistence of installed programs and archived variables across app restarts.

## Test plan
- [ ] Build iOS with Rust backend
- [ ] Install a program or archive a variable
- [ ] Background app and kill
- [ ] Relaunch and verify program/variable persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)