### PR TITLE
fix(web): prevent top cutoff on mobile viewports

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,11 +20,13 @@ function App() {
       inset: 0,
       display: 'flex',
       justifyContent: 'center',
-      alignItems: 'center',
+      alignItems: 'flex-start',
       background: '#111',
       overflowY: 'auto',
     }}>
-      <Calculator useBundledRom={true} defaultBackend="cemu" fullscreen />
+      <div style={{ marginTop: 'auto', marginBottom: 'auto', paddingTop: '1rem', paddingBottom: '1rem' }}>
+        <Calculator useBundledRom={true} defaultBackend="cemu" fullscreen />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Fix calculator UI being cut off at the top on mobile devices
- Replace `alignItems: 'center'` with `flex-start` + `margin: auto` wrapper to avoid the well-known flexbox centering overflow bug
- Add top/bottom padding so content isn't flush against viewport edges

## Test plan
- [ ] Open the demo page on a mobile device or narrow/short viewport
- [ ] Verify the calculator is fully visible and scrollable from the top
- [ ] Verify it still centers on larger screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)